### PR TITLE
feat: add a scriv-based changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+This file includes a history of past releases. Changes that were not yet added to a release are in the [changelog.d/](./changelog.d) folder.
+
+<!--
+⚠️ DO NOT ADD YOUR CHANGES TO THIS FILE! (unless you want to modify existing changelog entries in this file)
+Changelog entries are managed by scriv. After you have made some changes to this repository, create a changelog entry with:
+    scriv create
+Edit and commit the newly-created file in changelog.d.
+
+If you need to create a new release, create a separate commit after running:
+    scriv collect
+-->
+
+<!-- scriv-insert-here -->

--- a/README.rst
+++ b/README.rst
@@ -159,9 +159,14 @@ The plugin API was upgraded from v0 to v1 in Tutor v13.2.0. This cookiecutter ge
 Troubleshooting
 ---------------
 
-This Tutor plugin template is maintained by `Kyle McCormick <https://github.com/kdmccormick>`_ from the `The Center for Reimagining Learning (tCRIL) <https://openedx.atlassian.net/wiki/spaces/COMM/pages/3241640370/tCRIL+Engineering+Team>`_. Community support is available from the official `Open edX forum <https://discuss.openedx.org>`_.
+This Tutor plugin template is maintained by `Kyle McCormick <https://github.com/kdmccormick>`_ from `Axim Collaborative <https://axim.org>`_. Community support is available from the official `Open edX forum <https://discuss.openedx.org>`_.
 
 Do you need help using this template? See the `troubleshooting <https://docs.tutor.overhang.io/troubleshooting.html>`__ section from the Tutor documentation.
+
+Contributing
+------------
+
+Pull requests are welcome! Please read the `"contributing" section from the Tutor documentation <https://docs.tutor.overhang.io/tutor.html#contributing>`__.
 
 License
 -------

--- a/changelog.d/20230609_104727_arbrandes.md
+++ b/changelog.d/20230609_104727_arbrandes.md
@@ -1,0 +1,1 @@
+- [Improvement] Add a changelog file to the repository. (by @arbrandes)

--- a/changelog.d/scriv.ini
+++ b/changelog.d/scriv.ini
@@ -1,0 +1,17 @@
+[scriv]
+categories =
+format = md
+md_header_level = 2
+new_fragment_template =
+    <!--
+    Create a changelog entry for every new user-facing change. Please respect the following instructions:
+    - Indicate breaking changes by prepending an explosion 💥 character.
+    - Prefix your changes with either [Bugfix], [Improvement], [Feature], [Security], [Deprecation].
+    - You may optionally append "(by @<author>)" at the end of the line, where "<author>" is either one (just one)
+    of your GitHub username, real name or affiliated organization. These affiliations will be displayed in
+    the release notes for every release.
+    -->
+
+    <!-- - 💥[Feature] Foobarize the blorginator. This breaks plugins by renaming the `FOO_DO` filter to `BAR_DO`. (by @regisb) -->
+    <!-- - [Improvement] This is a non-breaking change. Life is good. (by @billgates) -->
+entry_title_template = {{ date.strftime('%%Y-%%m-%%d') }}


### PR DESCRIPTION
Adds a scriv-based changelog to this repository, modeled after https://github.com/overhangio/tutor-ecommerce/pull/39.

Closes #20.