### PR TITLE
refactor: using tasks directory instead of jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,10 @@ generate-plugin-for-tests:  ## Generate a plugin using the cookiecutter defaults
 	# The cookiecutter has many example code blocks prefixed with '### '.
 	# To help ensure that the example code would work if the user uncommented it,
 	# we remove the all '### ' occurances before running tests.
-	sed -i 's/### //' tutor-contrib-myplugin/tutormyplugin/plugin.py 
+	sed -i 's/### //' tutor-contrib-myplugin/tutormyplugin/plugin.py
 	# We must also create this init task template, which the cookiecutter
 	# doesn't generate because its usage in plugin.py is commented out.
-	touch tutor-contrib-myplugin/tutormyplugin/templates/myplugin/jobs/init/lms.sh
+	touch tutor-contrib-myplugin/tutormyplugin/templates/myplugin/tasks/lms/init.sh
 	@echo "$(MSG)Plugin generated.$(END_MSG)"
 
 test-plugin: test-plugin-quality test-plugin-install  ## Test the default plugin.

--- a/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/plugin.py
+++ b/{{ cookiecutter.package_name }}/{{ cookiecutter.module_name }}/plugin.py
@@ -49,14 +49,14 @@ hooks.Filters.CONFIG_OVERRIDES.add_items(
 ########################################
 
 # To add a custom initialization task, create a bash script template under:
-# {{ cookiecutter.module_name }}/templates/{{ cookiecutter.plugin_name }}/jobs/init/
+# {{ cookiecutter.module_name }}/templates/{{ cookiecutter.plugin_name }}/tasks/
 # and then add it to the MY_INIT_TASKS list. Each task is in the format:
 # ("<service>", ("<path>", "<to>", "<script>", "<template>"))
 MY_INIT_TASKS: list[tuple[str, tuple[str, ...]]] = [
     # For example, to add LMS initialization steps, you could add the script template at:
-    # {{ cookiecutter.module_name }}/templates/{{ cookiecutter.plugin_name }}/jobs/init/lms.sh
+    # {{ cookiecutter.module_name }}/templates/{{ cookiecutter.plugin_name }}/tasks/lms/init.sh
     # And then add the line:
-    ### ("lms", ("{{ cookiecutter.plugin_name }}", "jobs", "init", "lms.sh")),
+    ### ("lms", ("{{ cookiecutter.plugin_name }}", "tasks", "lms", "init.sh")),
 ]
 
 


### PR DESCRIPTION
tasks directory in the cookie-cutter is called "jobs", but everywhere is "tasks".
This will fix the inconsistency.