### PR TITLE
feat: changelog commands added

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,12 @@ test-plugin-install:  ## Smoke-test that the default plugin works with Tutor.
 	tutor myplugin example-command # This should just print a line and exit 0.
 	@echo "$(MSG)It seems like the generated plugin works with Tutor.$(END_MSG)"
 
+changelog-entry: ## Create a new changelog entry.
+	scriv create
+
+changelog: ## Collect changelog entries in the CHANGELOG.md file.
+	scriv collect
+
 ESCAPE = 
 help: ## Print this help
 	@grep -E '^([a-zA-Z_-]+:.*?## .*|######* .+)$$' Makefile \


### PR DESCRIPTION
since all of the plugins have a change log, it's better to have the command included in the Makefile of the plugin. 
also, is there a conclusion on the https://github.com/overhangio/cookiecutter-tutor-plugin/issues/20?