### PR TITLE
chore: mark compatibility with python 3.11 and 3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Please respect the following instructions:
 
 # Changelog
 
+## 2023-11-21
+
+- [Improvement] Mark compatibility with python 3.11 and 3.12 (by @CodeWithEmad).
+
 ## 2023-11-06
 
 - [Improvement] Recommend putting job scripts under "tasks" directory instead of "jobs", for consistency with official plugins (by @CodeWithEmad).

--- a/{{ cookiecutter.package_name }}/setup.py
+++ b/{{ cookiecutter.package_name }}/setup.py
@@ -55,5 +55,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
 )


### PR DESCRIPTION
with this, we make sure all of the newly created plugins will support the latest python which is 3.12 at the moment.