### PR TITLE
fix: docs improvement

### DIFF
--- a/{{ cookiecutter.package_name }}/README.rst
+++ b/{{ cookiecutter.package_name }}/README.rst
@@ -1,5 +1,6 @@
-{{ cookiecutter.plugin_name}} plugin for `Tutor <https://docs.tutor.edly.io>`__
-###############################################################################
+{{ cookiecutter.plugin_name }} plugin for `Tutor <https://docs.tutor.edly.io>`__
+{%- set heading_underline_length = (cookiecutter.plugin_name | length + 50) %}
+{{ '#' * heading_underline_length }}
 
 {{ cookiecutter.description }}
 
@@ -18,7 +19,7 @@ Usage
 
     tutor plugins enable {{ cookiecutter.plugin_name }}
 
-{%- if cookiecutter.license != 'Not open source' %}
+{% if cookiecutter.license != 'Not open source' %}
 License
 *******
 


### PR DESCRIPTION
README heading symbol '#' is now calculated and license condition is not whitespace controlled.