### PR TITLE
chore: remove Python 3.8 references

### DIFF
--- a/{{ cookiecutter.package_name }}/.github/workflows/test.yml
+++ b/{{ cookiecutter.package_name }}/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-         python-version: ['3.8', '3.12']
+         python-version: ['3.9', '3.12']
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python {{ '${{ matrix.python-version }}' }}

--- a/{{ cookiecutter.package_name }}/setup.py
+++ b/{{ cookiecutter.package_name }}/setup.py
@@ -41,7 +41,7 @@ setup(
     long_description_content_type="text/x-rst",
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=["tutor>={{ cookiecutter.tutor_version }}.0.0,<{{ cookiecutter.tutor_version + 1 }}.0.0"],
     extras_require={
         "dev": [
@@ -69,7 +69,6 @@ setup(
         {%- endif %}
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
Achieves part of https://github.com/overhangio/tutor/issues/1129,

- Minimum Python version bumped from 3.8 to 3.9
