### PR TITLE
chore: Rename branches master->release, nightly->main

### DIFF
--- a/{{ cookiecutter.package_name }}/.github/workflows/test.yml
+++ b/{{ cookiecutter.package_name }}/.github/workflows/test.yml
@@ -2,7 +2,9 @@ name: Run tests
 
 on:
   pull_request:
-    branches: [master]
+    branches: [ release, main ]
+  push:
+    branches: [ release, main ]
 
 jobs:
   tests:


### PR DESCRIPTION
Part of overhangio/tutor#1096, updates the cookiecutter GA to use updated branch names 