### PR TITLE
fix: author name, email and license name in pyproject.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please respect the following instructions:
 ## 2025-02-18
 
 - [Bugfix] Display author name and email separately when running `pip show plugin`. (by @Danyal-Faheem)
+- [Bugfix] Display license names as specified in the SPDX license list instead of the entire file when running `pip show plugin`. (by @Danyal-Faheem)
 
 ## 2025-01-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Please respect the following instructions:
 
 # Changelog
 
+## 2025-02-18
+
+- [Bugfix] Display author name and email separately when running `pip show plugin`. (by @Danyal-Faheem)
+
 ## 2025-01-30
 
 - [Improvement] Migrate from `setup.py` (setuptools) to `pyproject.toml` (hatch) (by @CodeWithEmad).

--- a/{{ cookiecutter.package_name }}/pyproject.toml
+++ b/{{ cookiecutter.package_name }}/pyproject.toml
@@ -9,9 +9,18 @@ authors = [
   { email = "{{ cookiecutter.email }}" },
 ]
 
-{%- if cookiecutter.license != "Not open source" %}
-license = {file = "LICENSE.txt"}
+{%- if cookiecutter.license == "AGPLv3" %}
+license = { text = "AGPL-3.0-only" }
+{%- elif cookiecutter.license == "Apache 2.0" %}
+license = { text = "Apache-2.0" }
+{%- elif cookiecutter.license == "BSDv3" %}
+license = { text = "BSD-3-Clause" }
+{%- elif cookiecutter.license == "MIT" %}
+license = { text = "MIT" }
+{%- elif cookiecutter.license == "Not open source" %}
+license = { text = "Proprietary" }
 {%- endif %}
+
 readme = {file = "README.rst", content-type = "text/x-rst"}
 requires-python = ">= 3.9"
 classifiers = [

--- a/{{ cookiecutter.package_name }}/pyproject.toml
+++ b/{{ cookiecutter.package_name }}/pyproject.toml
@@ -5,7 +5,8 @@
 name = "{{ cookiecutter.package_name }}"
 description = "{{ cookiecutter.description }}"
 authors = [
-  { name = "{{ cookiecutter.author }}", email = "{{ cookiecutter.email }}" },
+  { name = "{{ cookiecutter.author }}"}, 
+  { email = "{{ cookiecutter.email }}" },
 ]
 
 {%- if cookiecutter.license != "Not open source" %}


### PR DESCRIPTION
Both of these issues have been mentioned in the parent epic: https://github.com/overhangio/tutor/issues/1190

The author name is a known issue where it would display both the email and name against the author name and email against the author-email field. By changing it to two different json objects, it displays name and email against their respective headings.

The license would display the entire file when we ran `pip show plugin` which would make everything cluttered, hence we decided to limit it to just the license name. Reference discussion: https://github.com/overhangio/tutor/pull/1163#discussion_r1944221401

P.S, I will need some confirmation on the BSD license name. We should be using the ones specified in the [SPDX License list](https://spdx.org/licenses/) but BSD has a lot of different names.