### PR TITLE
chore: add hatch_build.py in sdist to avoid errors in pip install

### DIFF
--- a/{{ cookiecutter.package_name }}/pyproject.toml
+++ b/{{ cookiecutter.package_name }}/pyproject.toml
@@ -75,7 +75,7 @@ packages = ["{{ cookiecutter.module_name }}"]
 [tool.hatch.build.targets.sdist]
 # Disable strict naming, otherwise twine is not able to detect name/version
 strict-naming = false
-include = [ "/{{ cookiecutter.module_name }}"]
+include = [ "/{{ cookiecutter.module_name }}", ".hatch_build.py"]
 exclude = ["tests*"]
 
 [project.entry-points."tutor.plugin.v1"]


### PR DESCRIPTION
Fix installation issue by adding hatch_build in sdist https://github.com/pypa/hatch/discussions/964#discussioncomment-6972973, https://github.com/overhangio/tutor/issues/1190#issuecomment-2717455419